### PR TITLE
Prevent data loss by storing original size in PNG tEXt chunk

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: install dependencies
+      run: sudo apt-get install -y libpng-dev
     # - name: configure
     #   run: ./configure
     - name: make

--- a/bin2png.c
+++ b/bin2png.c
@@ -34,13 +34,13 @@
 
 static void do_work(const options_t *options, void *data, size_t filesize) {
 	const uint8_t channels = 4;
-	const uint32_t width = ceil(sqrt(filesize / channels));
-	const uint32_t height = ceil(filesize / channels / width) + 1;
+	const uint32_t width = ceil(sqrt((double)filesize / channels));
+	const uint32_t height = ceil((double)filesize / channels / width);
 	const uint32_t padding = width * height * channels - filesize;
 
 	printf("Input file => %s\n  size => %zu bytes\n", options->input, filesize);
 
-	bool ok = png_save(options->output, data, width, height, channels, padding, options->pad_byte);
+	bool ok = png_save(options->output, data, width, height, channels, padding, options->pad_byte, filesize);
 	if (ok) {
 		printf("Output file => %s\n  size => %zu bytes\n  image => %ux%u px, %d bpp, %upx padding\n",
 			options->output, fsize(options->output), width, height, channels * 8, padding / channels);

--- a/imgify.c
+++ b/imgify.c
@@ -250,7 +250,6 @@ bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t heig
 			memset(padded_row_ptr, pad_byte, rowbytes);
 			memcpy(padded_row_ptr, row_ptr, rowbytes - padding);
 			png_write_row(png_ptr, padded_row_ptr);
-			free(padded_row_ptr);
 		}
 	}
 

--- a/imgify.c
+++ b/imgify.c
@@ -38,8 +38,9 @@ static uint8_t* pixel_at(uint8_t *data, uint32_t row, uint32_t col, uint32_t wid
 }
 
 #define PNG_SIG_SIZE 8
+#define ORIGINAL_SIZE_CHUNK_KEY "osz"
 
-bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_size, uint32_t *out_width, uint32_t *out_height, uint8_t *out_channels, uint32_t *out_padding, uint8_t pad_byte) {
+bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_size, uint32_t *out_width, uint32_t *out_height, uint8_t *out_channels, uint32_t *out_padding) {
 	// Open the file.
 	FILE *fp = fopen(filename, "rb");
 	if (fp == NULL) {
@@ -134,30 +135,37 @@ bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_siz
 	// Read the entire image.
 	png_read_image(png_ptr, row_pointers);
 
+	// Finish reading
+	png_read_end(png_ptr, info_ptr);
+
+	size_t original_size = rowbytes * height; // Default to full image size (no padding)
+	uint32_t padding = 0;
+
+	png_textp text_ptr;
+	int num_text;
+
+	// Try to read original size from tEXt chunk
+	// If no original size chunk found, assume file perfectly fills the image (no padding)
+	if (png_get_text(png_ptr, info_ptr, &text_ptr, &num_text) > 0) {
+		for (int i = 0; i < num_text; i++) {
+			if (strcmp(text_ptr[i].key, ORIGINAL_SIZE_CHUNK_KEY) == 0) {
+				original_size = strtoull(text_ptr[i].text, NULL, 10);
+				padding = rowbytes * height - original_size;
+				break;
+			}
+		}
+	}
+
 	// Clean up.
 	free(row_pointers);
 	row_pointers = NULL;
 	png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 	fclose(fp);
 
-	// Calculate padding.
-	const uint8_t *last_row = pixel_at(data, height-1, 0, width, height, channels);
-	uint32_t padding = 0;
-	for (uint32_t i = 0; i < rowbytes; ++i) {
-		uint32_t column = rowbytes - i;
-		// Stop when the padding byte is no longer found.
-		if (last_row[column-1] != pad_byte) {
-			padding = i;
-			// printf("DEBUG: [png_load] Found %u pixels of padding (%u bytes), starting at row %u column %u\n",
-			// 	padding / channels, padding, height, column);
-			break;
-		}
-	}
-
 	if (out_buffer != NULL)
 		*out_buffer = data;
 	if (out_buffer_size != NULL)
-		*out_buffer_size = rowbytes * height - padding;
+		*out_buffer_size = original_size;
 	if (out_width != NULL)
 		*out_width = width;
 	if (out_height != NULL)
@@ -170,7 +178,7 @@ bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_siz
 	return true;
 }
 
-bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t height, uint8_t channels, uint32_t padding, uint8_t pad_byte) {
+bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t height, uint8_t channels, uint32_t padding, uint8_t pad_byte, size_t original_size) {
 	assert(width > 0); // 1 column at least
 	assert(height > 0); // 1 row at least
 
@@ -222,6 +230,18 @@ bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t heig
 	// Set the PNG header info.
 	png_set_IHDR(png_ptr, info_ptr, width, height, bit_depth, color_type,
 			PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+
+	// Add tEXt chunk with original file size only if padding is required
+	const size_t total_capacity = width * height * channels;
+	if (original_size < total_capacity) {
+		char size_text[32];
+		snprintf(size_text, sizeof(size_text), "%zu", original_size);
+		png_text text_chunk;
+		text_chunk.key = ORIGINAL_SIZE_CHUNK_KEY;
+		text_chunk.text = size_text;
+		text_chunk.compression = PNG_TEXT_COMPRESSION_NONE;
+		png_set_text(png_ptr, info_ptr, &text_chunk, 1);
+	}
 
 	// Write the info.
 	png_write_info(png_ptr, info_ptr);

--- a/imgify.h
+++ b/imgify.h
@@ -3,5 +3,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_size, uint32_t *out_width, uint32_t *out_height, uint8_t *out_channels, uint32_t *out_padding, uint8_t pad_byte);
-bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t height, uint8_t channels, uint32_t padding, uint8_t pad_byte);
+bool png_load(const char *filename, uint8_t **out_buffer, size_t *out_buffer_size, uint32_t *out_width, uint32_t *out_height, uint8_t *out_channels, uint32_t *out_padding);
+bool png_save(const char *filename, uint8_t *data, uint32_t width, uint32_t height, uint8_t channels, uint32_t padding, uint8_t pad_byte, size_t original_size);

--- a/png2bin.c
+++ b/png2bin.c
@@ -40,7 +40,7 @@ static void do_work(const options_t *options, void *data, size_t filesize) {
 	uint8_t channels;
 	uint32_t padding;
 
-	const bool ok = png_load(options->input, &buffer, &buffer_size, &width, &height, &channels, &padding, options->pad_byte);
+	const bool ok = png_load(options->input, &buffer, &buffer_size, &width, &height, &channels, &padding);
 
 	if (ok) {
 		printf("Input file => %s\n  size => %zu bytes\n  image => %ux%u px, %d bpp, %upx padding\n",


### PR DESCRIPTION
Replace our naive padding detection that truncated files ending with `pad_byte` values.
Now we store the original size as PNG metadata using key "osz" - fixes #4 
This PR also fixes a double-free and the integer divisions in dimension calculation.

